### PR TITLE
Wire up wms proxy

### DIFF
--- a/client/src/app/map/map.component.ts
+++ b/client/src/app/map/map.component.ts
@@ -148,10 +148,10 @@ export class MapComponent implements OnInit {
                             var imageUrl = urlCreator.createObjectURL(data);
                             imageTile.getImage().src = imageUrl;
                         },
-                            error => {
-                                // TODO: potentially handle error?
-                            }
-                        )
+                        error => {
+                            // TODO: potentially handle error?
+                        }
+                    )
                 }.bind(this)
             });
              var layer = new ol.layer.Tile({

--- a/client/src/app/map/map.service.spec.ts
+++ b/client/src/app/map/map.service.spec.ts
@@ -1,11 +1,21 @@
 import { TestBed, inject } from '@angular/core/testing';
+import { HttpModule } from '@angular/http';
 
 import { MapService } from './map.service';
+import { AuthenticationService } from './../shared/authentication.service';
 
 describe('MapService', () => {
+  
+  // Mock
+  let authenticationServiceStub = {};
+  
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [MapService]
+      imports: [HttpModule],
+      providers: [
+        MapService, 
+        {provide: AuthenticationService, useValue: authenticationServiceStub}
+      ]
     });
   });
 

--- a/client/src/app/map/map.service.ts
+++ b/client/src/app/map/map.service.ts
@@ -53,7 +53,6 @@ export class MapService {
     getTile(url){
         let headers = new Headers();
         let token = this.authenticationService.getToken();
-        headers.append('Content-Type', 'application/json; charset=UTF-8');
         headers.append('Authorization', 'Bearer ' + token);
         headers.append('Accept', 'image/png');
 

--- a/client/src/app/map/map.service.ts
+++ b/client/src/app/map/map.service.ts
@@ -65,13 +65,4 @@ export class MapService {
         return this.http.get(url, options)
             .map(response => (<Response>response).blob())
     }
-
-    /**
-     * Handle the error
-     * @param error
-     * @returns {ErrorObservable}
-     */
-    private handleError(error:Response | any) {
-        return Observable.throw(error);
-    }
 }

--- a/client/src/app/map/map.service.ts
+++ b/client/src/app/map/map.service.ts
@@ -1,5 +1,10 @@
 import {Injectable} from '@angular/core';
+import { Http, Headers, Response, RequestOptions, ResponseContentType } from '@angular/http';
+import { Observable } from 'rxjs/Observable';
 import * as ol from 'openlayers';
+
+import { AuthenticationService } from './../shared/authentication.service';
+
 
 @Injectable()
 export class MapService {
@@ -7,8 +12,10 @@ export class MapService {
     map:any;
     self = this;
 
-    constructor() {
-    }
+    constructor(
+        private authenticationService: AuthenticationService,
+        private http: Http
+    ) {}
 
     /**
      * Initialise an OpenLayers map
@@ -36,5 +43,35 @@ export class MapService {
      */
     getMap() {
         return this.map;
+    }
+
+    /**
+     * Get the tile by adding authentication headers
+     * @param url
+     * @returns {any|Promise<R>|Maybe<T>}
+     */
+    getTile(url){
+        let headers = new Headers();
+        let token = this.authenticationService.getToken();
+        headers.append('Content-Type', 'application/json; charset=UTF-8');
+        headers.append('Authorization', 'Bearer ' + token);
+        headers.append('Accept', 'image/png');
+
+        let options = new RequestOptions({
+            headers: headers,
+            responseType: ResponseContentType.Blob
+        });
+
+        return this.http.get(url, options)
+            .map(response => (<Response>response).blob())
+    }
+
+    /**
+     * Handle the error
+     * @param error
+     * @returns {ErrorObservable}
+     */
+    private handleError(error:Response | any) {
+        return Observable.throw(error);
     }
 }


### PR DESCRIPTION
Adds an authentication header to the WMS request and sends the request to the API instead of straight to GeoServer