### PR TITLE
bugfix for show hide sidebar

### DIFF
--- a/client/src/app/map/map.component.html
+++ b/client/src/app/map/map.component.html
@@ -10,19 +10,19 @@
                 </ul>
             </div>
             <!-- Tab panes -->
-            <div *ngIf="showContent" class="sidebar-content">
+            <div [hidden]="!showContent" class="sidebar-content">
                 <div class="sidebar-pane active" id="home">
                     <h1 class="sidebar-header pointer" title="Change category"
                         [ngClass]="{'preparedness-bg': category === 'preparedness', 'incidents-bg': category === 'incidents', 'assessment-bg': category === 'assessment'}"
                         (click)="toggleCategoryPicker()">
-                        <span *ngIf="category === 'preparedness'">Preparedness</span>
-                        <span *ngIf="category === 'incidents'">Incidents and Warnings</span>
-                        <span *ngIf="category === 'assessment'">Assessment and Response</span>
+                        <span [hidden]="category !== 'preparedness'">Preparedness</span>
+                        <span [hidden]="category !== 'incidents'">Incidents and Warnings</span>
+                        <span [hidden]="category !== 'assessment'">Assessment and Response</span>
                         <span class="sidebar-toggle">
                             <i class="fa fa-caret-down"></i>
                         </span>
                     </h1>
-                    <div class="switch-category" *ngIf="showCategoryPicker">
+                    <div class="switch-category" [hidden]="!showCategoryPicker">
                         <div class="preparedness-fg" (click)="setCategory('preparedness')">
                             <h4>Preparedness</h4>
                         </div>
@@ -33,7 +33,7 @@
                             <h4>Assessment and Response</h4>
                         </div>
                     </div>
-                    <div *ngIf="category === 'preparedness'">
+                    <div [hidden]="category !== 'preparedness'">
                         <div *ngFor="let layerGroup of preparednessLayers | groupBy: 'layerGroup'">
                             <h3>{{ layerGroup.key }}</h3>
                             <div *ngFor="let layer of layerGroup.value; index as i; trackBy: trackByFn">
@@ -44,10 +44,10 @@
                             </div>
                         </div>
                     </div>
-                    <div *ngIf="category === 'incidents'">
+                    <div [hidden]="category !== 'incidents'">
                         TODO
                     </div>
-                    <div *ngIf="category === 'assessment'">
+                    <div [hidden]="category !== 'assessment'">
                         TODO
                     </div>
                 </div>


### PR DESCRIPTION
Bugfix for https://github.com/thinkWhere/DMIS/issues/31

ngIf removes elements from the DOM if it is false. When it is shown again, it will redraw the DOM elements so it loses the ticked boxes. Instead of using ngIf, [hidden] is now used. [hidden] can be overwritten easily with CSS so we need to keep an eye on that.