### PR TITLE
add buffer to identify

### DIFF
--- a/client/src/app/map/identify.service.ts
+++ b/client/src/app/map/identify.service.ts
@@ -68,7 +68,8 @@ export class IdentifyService {
                 evt.coordinate, viewResolution, 'EPSG:3857',
                 {
                     'INFO_FORMAT': 'application/json',
-                    'FEATURE_COUNT': this.maxFeatureCount
+                    'FEATURE_COUNT': this.maxFeatureCount,
+                    'BUFFER': 10
                 });
             var identifiableLayers = this.layerService.getIdentifiableLayers(map);
             url = this.updateUrlParameter(url, 'QUERY_LAYERS', identifiableLayers.join());


### PR DESCRIPTION
Add buffer to make it easier to identify points

5 seems to be the default. I have increased it to 10 in the GetFeatureInfo request.
http://docs.geoserver.org/latest/en/user/services/wms/vendor.html