### PR TITLE
Bugfix ie caching

### DIFF
--- a/client/src/app/admin/layers/layer.component.ts
+++ b/client/src/app/admin/layers/layer.component.ts
@@ -76,7 +76,6 @@ export class LayerComponent implements OnInit {
       layer.mapCategory = this.selectedCategory.value;
       this.editMode = false;
       this.errorUpdatingLayer = false;
-      console.log(layer)
       this.layerService.updateLayer(layer)
       .subscribe(
           data => {

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -17,6 +17,9 @@ import { SitrepComponent } from './map/sitrep.component';
 import { FaqComponent } from './faq/faq.component';
 import { WeatherComponent } from './weather/weather.component';
 
+import { RequestOptions } from '@angular/http';
+import { RequestOptionsService } from './shared/request-options.service';
+
 @NgModule({
   declarations: [
     AppComponent,
@@ -66,7 +69,9 @@ import { WeatherComponent } from './weather/weather.component';
           }
       ])
   ],
-  providers: [AuthenticationService, AuthGuardService],
+  providers: [AuthenticationService, AuthGuardService, {
+    provide: RequestOptions, useClass: RequestOptionsService
+  }],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/client/src/app/shared/request-options.service.spec.ts
+++ b/client/src/app/shared/request-options.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { RequestOptionsService } from './request-options.service';
+
+describe('RequestOptionsService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [RequestOptionsService]
+    });
+  });
+
+  it('should be created', inject([RequestOptionsService], (service: RequestOptionsService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/client/src/app/shared/request-options.service.ts
+++ b/client/src/app/shared/request-options.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { BaseRequestOptions, RequestOptions, RequestOptionsArgs } from '@angular/http';
+
+@Injectable()
+export class RequestOptionsService extends BaseRequestOptions {
+
+  constructor() {
+    super();
+  }
+
+  /**
+   * Add cache control headers to ensure that IE & Edge don't use the cache for API calls
+   * https://blog.alex-miller.co/angular/2017/05/13/default-headers-in-angular.html
+   * If using the newer HttpClient instead of Http, you can use interceptors.
+   * TODO: review refactor of moving from Http to HttpClient in whole application so interceptors can be used
+   * @param options
+   * @returns {RequestOptions}
+   */
+  merge(options?:RequestOptionsArgs): RequestOptions {
+    const newOptions = super.merge(options);
+    // Don't override the headers when they are not set. Otherwise an error occurs: Request header field Cache-Control is not allowed by Access-Control-Allow-Headers in preflight response.
+    if (options.headers){
+      newOptions.headers.append('Cache-Control', 'no-cache');
+      newOptions.headers.append('Expires', '-1');
+      newOptions.headers.append('Pragma', 'no-cache');
+    }
+    return newOptions;
+  }
+}


### PR DESCRIPTION
Bugfix for IE and Edge caching API calls. I have added a RequestOptionsService which intercepts any HTTP calls and adds additional headers which tell IE and Edge (and all other browsers too) not to use the cache. 

Ideally we'd use the Angular Interceptor service but then you seem to have to use the new HttpClient instead of Http package and this switch would require a proper refactor so I have left it at this for now.